### PR TITLE
Add some checks on returning from PyObject_CallMethodArgs()

### DIFF
--- a/packages/rol/pyrol/include/PyROL_EqualityConstraint_Impl.hpp
+++ b/packages/rol/pyrol/include/PyROL_EqualityConstraint_Impl.hpp
@@ -54,12 +54,12 @@ namespace PyROL {
 */
 
 
-EqualityConstraint::EqualityConstraint( PyObject* pyEqCon ) : 
+EqualityConstraint::EqualityConstraint( PyObject* pyEqCon ) :
     ROL::EqualityConstraint<double>(),
   AttributeManager( pyEqCon, attrList_, className_ ),
   pyEqCon_(pyEqCon) {
   Py_INCREF(pyEqCon_);
-}    
+}
 
 EqualityConstraint::~EqualityConstraint() {
   Py_DECREF(pyEqCon_);
@@ -71,9 +71,10 @@ void EqualityConstraint::value(ROL::Vector<double> &c, const ROL::Vector<double>
   PyObject* pyTol = PyFloat_FromDouble(tol);
   PyObject_CallMethodObjArgs(pyEqCon_,method_["value"].name,
     pyC,pyX,pyTol,NULL);
+  if (PyErr_Occurred() != NULL) PyErr_Print();
 }
 
-void EqualityConstraint::applyJacobian(ROL::Vector<double> &jv, const ROL::Vector<double> &v, 
+void EqualityConstraint::applyJacobian(ROL::Vector<double> &jv, const ROL::Vector<double> &v,
                                        const ROL::Vector<double> &x, double &tol) {
   if( method_["applyJacobian"].impl ) {
     PyObject* pyJv = PyObject_FromVector(jv);
@@ -82,14 +83,15 @@ void EqualityConstraint::applyJacobian(ROL::Vector<double> &jv, const ROL::Vecto
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject_CallMethodObjArgs(pyEqCon_,method_["applyJacobian"].name,
       pyJv,pyV,pyX,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyTol);
   }
   else {
-    ROL::EqualityConstraint<double>::applyJacobian(jv, v, x, tol); 
+    ROL::EqualityConstraint<double>::applyJacobian(jv, v, x, tol);
   }
 }
 
-void EqualityConstraint::applyAdjointJacobian(ROL::Vector<double> &ajv, const ROL::Vector<double> &v, 
+void EqualityConstraint::applyAdjointJacobian(ROL::Vector<double> &ajv, const ROL::Vector<double> &v,
                                               const ROL::Vector<double> &x, double &tol) {
   if( method_["applyAdjointJacobian"].impl ) {
     PyObject* pyAjv = PyObject_FromVector(ajv);
@@ -98,17 +100,18 @@ void EqualityConstraint::applyAdjointJacobian(ROL::Vector<double> &ajv, const RO
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject_CallMethodObjArgs(pyEqCon_,method_["applyAdjointJacobian"].name,
       pyAjv,pyV,pyX,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyTol);
   }
   else {
-    ROL::EqualityConstraint<double>::applyAdjointJacobian(ajv, v, x, tol); 
+    ROL::EqualityConstraint<double>::applyAdjointJacobian(ajv, v, x, tol);
   }
 
 }
 
 // TODO: Add dual versions
 
-void EqualityConstraint::applyAdjointHessian(ROL::Vector<double> &ahuv, const ROL::Vector<double> &u, 
+void EqualityConstraint::applyAdjointHessian(ROL::Vector<double> &ahuv, const ROL::Vector<double> &u,
                                              const ROL::Vector<double> &v, const ROL::Vector<double> &x, double &tol) {
   if( method_["applyAdjointHessian"].impl ) {
     PyObject* pyAhuv = PyObject_FromVector(ahuv);
@@ -118,16 +121,17 @@ void EqualityConstraint::applyAdjointHessian(ROL::Vector<double> &ahuv, const RO
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject_CallMethodObjArgs(pyEqCon_,method_["applyAdjointHessian"].name,
       pyAhuv,pyU,pyV,pyX,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyTol);
   }
   else {
-    ROL::EqualityConstraint<double>::applyAdjointHessian(ahuv, u, v, x, tol); 
+    ROL::EqualityConstraint<double>::applyAdjointHessian(ahuv, u, v, x, tol);
   }
 }
 
-std::vector<double> 
-EqualityConstraint::solveAugmentedSystem(ROL::Vector<double> &v1,  ROL::Vector<double> &v2, 
-                                         const ROL::Vector<double> &b1, const ROL::Vector<double> &b2, 
+std::vector<double>
+EqualityConstraint::solveAugmentedSystem(ROL::Vector<double> &v1,  ROL::Vector<double> &v2,
+                                         const ROL::Vector<double> &b1, const ROL::Vector<double> &b2,
                                          const ROL::Vector<double> &x, double &tol) {
   if( method_["solveAugmentedSystem"].impl ) {
     PyObject* pyV1 = PyObject_FromVector(v1);
@@ -138,18 +142,19 @@ EqualityConstraint::solveAugmentedSystem(ROL::Vector<double> &v1,  ROL::Vector<d
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject_CallMethodObjArgs(pyEqCon_,method_["solveAugmentedSystem"].name,
       pyV1,pyV2,pyB1,pyB2,pyX,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyTol);
     // TODO
     return std::vector<double>();
   }
   else {
-    return ROL::EqualityConstraint<double>::solveAugmentedSystem(v1, v2, b1, b2, x, tol); 
+    return ROL::EqualityConstraint<double>::solveAugmentedSystem(v1, v2, b1, b2, x, tol);
   }
 }
 
 
-void EqualityConstraint::applyPreconditioner(ROL::Vector<double> &pv, const ROL::Vector<double> &v, 
-                                             const ROL::Vector<double> &x, const ROL::Vector<double> &g, 
+void EqualityConstraint::applyPreconditioner(ROL::Vector<double> &pv, const ROL::Vector<double> &v,
+                                             const ROL::Vector<double> &x, const ROL::Vector<double> &g,
                                              double &tol) {
   if( method_["applyPreconditioner"].impl ) {
     PyObject* pyPv = PyObject_FromVector(pv);
@@ -159,14 +164,15 @@ void EqualityConstraint::applyPreconditioner(ROL::Vector<double> &pv, const ROL:
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject_CallMethodObjArgs(pyEqCon_,method_["applyPreconditioner"].name,
       pyPv,pyV,pyX,pyG,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyTol);
   }
   else {
-    ROL::EqualityConstraint<double>::applyPreconditioner(pv, v, x, g, tol); 
+    ROL::EqualityConstraint<double>::applyPreconditioner(pv, v, x, g, tol);
   }
 }
 
-void EqualityConstraint::update( const ROL::Vector<double> &x, 
+void EqualityConstraint::update( const ROL::Vector<double> &x,
                                  bool flag, int iter ) {
   if( method_["update"].impl ) {
     const PyObject* pyX = PyObject_FromVector(x);
@@ -174,22 +180,24 @@ void EqualityConstraint::update( const ROL::Vector<double> &x,
     PyObject* pyIter = PyLong_FromLong(static_cast<long>(iter));
     PyObject_CallMethodObjArgs(pyEqCon_,method_["update"].name,
       pyX,pyFlag,pyIter,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyFlag);
     Py_DECREF(pyIter);
   }
 }
 
-bool EqualityConstraint::isFeasible( const ROL::Vector<double> &v ) { 
+bool EqualityConstraint::isFeasible( const ROL::Vector<double> &v ) {
   if( method_["isFeasible"].impl ) {
     const PyObject* pyV = PyObject_FromVector(v);
     PyObject* pyFeasible = PyObject_CallMethodObjArgs(pyEqCon_,
       method_["isFeasible"].name,pyV,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     bool feasible = static_cast<bool>(PyLong_AsLong(pyFeasible));
     Py_DECREF(pyFeasible);
     return feasible;
   }
   else {
-    return true; 
+    return true;
   }
 }
 

--- a/packages/rol/pyrol/include/PyROL_Objective_Impl.hpp
+++ b/packages/rol/pyrol/include/PyROL_Objective_Impl.hpp
@@ -70,7 +70,7 @@ void Objective::update( const ROL::Vector<double> &x, bool flag, int iter ) {
     PyObject* pyIter = PyLong_FromLong(static_cast<long>(iter));
 
     PyObject_CallMethodObjArgs(pyObjective_,method_["update"].name,pyX,pyFlag,pyIter,NULL);
-
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyFlag);
     Py_DECREF(pyIter);
   }
@@ -80,6 +80,7 @@ double Objective::value( const ROL::Vector<double> &x, double &tol ) {
   const PyObject* pyX = PyObject_FromVector(x);
   PyObject* pyTol = PyFloat_FromDouble(tol);
   PyObject* pyValue = PyObject_CallMethodObjArgs(pyObjective_,method_["value"].name,pyX,pyTol,NULL);
+  if (PyErr_Occurred() != NULL) PyErr_Print();
   TEUCHOS_TEST_FOR_EXCEPTION(!PyFloat_Check(pyValue), std::logic_error,
                              "value() returned incorrect type");
   double val = PyFloat_AsDouble(pyValue);
@@ -94,6 +95,7 @@ void Objective::gradient( ROL::Vector<double> &g, const ROL::Vector<double> &x, 
     const PyObject* pyX = PyObject_FromVector(x);
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject_CallMethodObjArgs(pyObjective_,method_["gradient"].name,pyG,pyX,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
   }
   else {
     ROL::Objective<double>::gradient(g,x,tol);
@@ -106,6 +108,7 @@ double Objective::dirDeriv( const ROL::Vector<double> &x, const ROL::Vector<doub
     const PyObject* pyD = PyObject_FromVector(d);
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject* pyResult = PyObject_CallMethodObjArgs(pyObjective_,method_["dirDeriv"].name,pyX,pyD,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     double result = PyFloat_AsDouble(pyResult);
     Py_DECREF(pyTol);
     Py_DECREF(pyResult);
@@ -123,6 +126,7 @@ void Objective::hessVec( ROL::Vector<double> &hv, const ROL::Vector<double> &v, 
     const PyObject* pyX = PyObject_FromVector(x);
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject_CallMethodObjArgs(pyObjective_,method_["hessVec"].name,pyHv,pyV,pyX,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyTol);
   }
   else {
@@ -137,6 +141,7 @@ void Objective::invHessVec( ROL::Vector<double> &hv, const ROL::Vector<double> &
     const PyObject* pyX = PyObject_FromVector(x);
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject_CallMethodObjArgs(pyObjective_,method_["invHessVec"].name,pyHv,pyV,pyX,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyTol);
   }
   else {
@@ -151,6 +156,7 @@ void Objective::precond( ROL::Vector<double> &Pv, const ROL::Vector<double> &v, 
     const PyObject* pyX = PyObject_FromVector(x);
     PyObject* pyTol = PyFloat_FromDouble(tol);
     PyObject_CallMethodObjArgs(pyObjective_,method_["precond"].name,pyPv,pyV,pyX,pyTol,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyTol);
   }
   else {

--- a/packages/rol/pyrol/include/PyROL_Objective_Impl.hpp
+++ b/packages/rol/pyrol/include/PyROL_Objective_Impl.hpp
@@ -68,9 +68,9 @@ void Objective::update( const ROL::Vector<double> &x, bool flag, int iter ) {
     const PyObject* pyX = PyObject_FromVector(x);
     PyObject* pyFlag = flag ? Py_True : Py_False;
     PyObject* pyIter = PyLong_FromLong(static_cast<long>(iter));
-    
+
     PyObject_CallMethodObjArgs(pyObjective_,method_["update"].name,pyX,pyFlag,pyIter,NULL);
-    
+
     Py_DECREF(pyFlag);
     Py_DECREF(pyIter);
   }
@@ -80,6 +80,8 @@ double Objective::value( const ROL::Vector<double> &x, double &tol ) {
   const PyObject* pyX = PyObject_FromVector(x);
   PyObject* pyTol = PyFloat_FromDouble(tol);
   PyObject* pyValue = PyObject_CallMethodObjArgs(pyObjective_,method_["value"].name,pyX,pyTol,NULL);
+  TEUCHOS_TEST_FOR_EXCEPTION(!PyFloat_Check(pyValue), std::logic_error,
+                             "value() returned incorrect type");
   double val = PyFloat_AsDouble(pyValue);
   Py_DECREF(pyTol);
   Py_DECREF(pyValue);
@@ -95,7 +97,7 @@ void Objective::gradient( ROL::Vector<double> &g, const ROL::Vector<double> &x, 
   }
   else {
     ROL::Objective<double>::gradient(g,x,tol);
-  } 
+  }
 }
 
 double Objective::dirDeriv( const ROL::Vector<double> &x, const ROL::Vector<double> &d, double &tol ) {
@@ -113,7 +115,7 @@ double Objective::dirDeriv( const ROL::Vector<double> &x, const ROL::Vector<doub
     return ROL::Objective<double>::dirDeriv(x,d,tol);
   }
 }
- 
+
 void Objective::hessVec( ROL::Vector<double> &hv, const ROL::Vector<double> &v, const ROL::Vector<double> &x, double &tol ) {
   if( method_["hessVec"].impl ) {
     PyObject* pyHv = Teuchos::dyn_cast<BaseVector>(hv).getPyVector();

--- a/packages/rol/pyrol/include/PyROL_PythonVector_Impl.hpp
+++ b/packages/rol/pyrol/include/PyROL_PythonVector_Impl.hpp
@@ -78,6 +78,8 @@ PythonVector::~PythonVector() {
 int PythonVector::dimension() const {
   if( method_["dimension"].impl ) {
     PyObject* pyDimension = PyObject_CallMethodObjArgs(pyVector_,method_["dimension"].name,NULL);
+    TEUCHOS_TEST_FOR_EXCEPTION(!PyLong_Check(pyDimension), std::logic_error,
+                               "dimension() returned incorrect type");
     return static_cast<int>(PyLong_AsLong(pyDimension));
   }
   else {
@@ -147,6 +149,8 @@ double PythonVector::dot( const ROL::Vector<double> &x ) const {
     PyObject* pyValue;
     // This is supposed to return a new reference
     pyValue = PyObject_CallMethodObjArgs(pyVector_,method_["dot"].name,pyX,NULL);
+    TEUCHOS_TEST_FOR_EXCEPTION(!PyFloat_Check(pyValue), std::logic_error,
+                               "dot() returned incorrect type");
     value = PyFloat_AsDouble(pyValue);
     Py_DECREF(pyValue);// causes seg fault
     // Py_XDECREF(pyValue);
@@ -166,6 +170,8 @@ double PythonVector::norm( ) const {
   if( method_["norm"].impl ) {
     PyObject* pyValue;
     pyValue = PyObject_CallMethodObjArgs(pyVector_,method_["norm"].name,NULL);
+    TEUCHOS_TEST_FOR_EXCEPTION(!PyFloat_Check(pyValue), std::logic_error,
+                               "norm() returned incorrect type");
     value = PyFloat_AsDouble(pyValue);
     Py_DECREF(pyValue);
   }
@@ -258,6 +264,8 @@ void PythonVector::setValue (int i, double value) {
 double PythonVector::getValue(int i) const {
   PyObject* pyIndex = PyLong_FromLong(static_cast<long>(i));
   PyObject* pyValue = PyObject_CallMethodObjArgs(pyVector_,method_["__getitem__"].name,pyIndex,NULL);
+  TEUCHOS_TEST_FOR_EXCEPTION(!PyFloat_Check(pyValue), std::logic_error,
+                             "__getitem__ returned incorrect type");
   double value = PyFloat_AsDouble(pyValue);
   Py_DECREF(pyIndex);
   return value;

--- a/packages/rol/pyrol/include/PyROL_PythonVector_Impl.hpp
+++ b/packages/rol/pyrol/include/PyROL_PythonVector_Impl.hpp
@@ -78,6 +78,7 @@ PythonVector::~PythonVector() {
 int PythonVector::dimension() const {
   if( method_["dimension"].impl ) {
     PyObject* pyDimension = PyObject_CallMethodObjArgs(pyVector_,method_["dimension"].name,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     TEUCHOS_TEST_FOR_EXCEPTION(!PyLong_Check(pyDimension), std::logic_error,
                                "dimension() returned incorrect type");
     return static_cast<int>(PyLong_AsLong(pyDimension));
@@ -90,6 +91,7 @@ int PythonVector::dimension() const {
 Teuchos::RCP<ROL::Vector<double>>
 PythonVector::clone() const {
   PyObject* pyClone = PyObject_CallMethodObjArgs(pyVector_,method_["clone"].name,NULL);
+  if (PyErr_Occurred() != NULL) PyErr_Print();
   Teuchos::RCP<ROL::Vector<double>> vclone = Teuchos::rcp( new PythonVector( pyClone, true ) );
   Py_INCREF(pyClone);
   return vclone;
@@ -98,12 +100,14 @@ PythonVector::clone() const {
 Teuchos::RCP<ROL::Vector<double>>
 PythonVector::basis( const int i ) const {
   PyObject* pyBasis = PyObject_CallMethodObjArgs(pyVector_,method_["clone"].name,NULL);
+  if (PyErr_Occurred() != NULL) PyErr_Print();
   Teuchos::RCP<ROL::Vector<double>> b = Teuchos::rcp( new PythonVector( pyBasis, true ) );
   Py_DECREF(pyBasis);
   b->zero();
   PyObject* pyIndex = PyLong_FromLong(static_cast<long>(i));
   PyObject* pyOne = PyFloat_FromDouble(1.0);
   PyObject_CallMethodObjArgs(pyVector_,method_["__setitem__"].name,pyIndex,pyOne,NULL);
+  if (PyErr_Occurred() != NULL) PyErr_Print();
   Py_DECREF(pyIndex);
   Py_DECREF(pyOne);
   return b;
@@ -112,6 +116,7 @@ PythonVector::basis( const int i ) const {
 const ROL::Vector<double> & PythonVector::dual() const {
   if( method_["dual"].impl ) {
     PyObject *pyDual = PyObject_CallMethodObjArgs(pyVector_,method_["dual"].name,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Teuchos::RCP<Vector> d = Teuchos::rcp( new PythonVector(pyDual,true) );
     return *d;
   }
@@ -125,6 +130,7 @@ void PythonVector::plus( const ROL::Vector<double> & x ) {
     // Borrowed reference
     const PyObject* pyX = PyObject_FromVector(x);
     PyObject_CallMethodObjArgs(pyVector_,method_["plus"].name,pyX,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
   }
   else {
     this->applyBinary(ROL::Elementwise::Plus<double>(),x);
@@ -135,6 +141,7 @@ void PythonVector::scale( const double alpha ) {
   if( method_["scale"].impl ) {
     PyObject* pyAlpha = PyFloat_FromDouble(alpha);
     PyObject_CallMethodObjArgs(pyVector_,method_["scale"].name,pyAlpha,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyAlpha);
   }
   else {
@@ -149,6 +156,7 @@ double PythonVector::dot( const ROL::Vector<double> &x ) const {
     PyObject* pyValue;
     // This is supposed to return a new reference
     pyValue = PyObject_CallMethodObjArgs(pyVector_,method_["dot"].name,pyX,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     TEUCHOS_TEST_FOR_EXCEPTION(!PyFloat_Check(pyValue), std::logic_error,
                                "dot() returned incorrect type");
     value = PyFloat_AsDouble(pyValue);
@@ -170,6 +178,7 @@ double PythonVector::norm( ) const {
   if( method_["norm"].impl ) {
     PyObject* pyValue;
     pyValue = PyObject_CallMethodObjArgs(pyVector_,method_["norm"].name,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     TEUCHOS_TEST_FOR_EXCEPTION(!PyFloat_Check(pyValue), std::logic_error,
                                "norm() returned incorrect type");
     value = PyFloat_AsDouble(pyValue);
@@ -190,6 +199,7 @@ void PythonVector::axpy( const double alpha, const ROL::Vector<double> &x ) {
     PyObject* pyAlpha = PyFloat_FromDouble(alpha);
     const PyObject* pyX = PyObject_FromVector(x);
     PyObject_CallMethodObjArgs(pyVector_,method_["axpy"].name,pyAlpha,pyX,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
     Py_DECREF(pyAlpha);
   }
   else {
@@ -204,6 +214,7 @@ void PythonVector::axpy( const double alpha, const ROL::Vector<double> &x ) {
 void PythonVector::zero( ) {
   if( method_["zero"].impl ) {
      PyObject_CallMethodObjArgs(pyVector_,method_["zero"].name,NULL);
+     if (PyErr_Occurred() != NULL) PyErr_Print();
   }
   else {
     int dim = dimension();
@@ -217,6 +228,7 @@ void PythonVector::set( const ROL::Vector<double> &x ) {
   if( method_["set"].impl ) {
     const PyObject* pyX = PyObject_FromVector(x);
     PyObject_CallMethodObjArgs(pyVector_,method_["set"].name,pyX,NULL);
+    if (PyErr_Occurred() != NULL) PyErr_Print();
   }
   else {
     const PythonVector ex = Teuchos::dyn_cast<const PythonVector>(x);
@@ -257,6 +269,7 @@ void PythonVector::setValue (int i, double value) {
   PyObject* pyIndex = PyLong_FromLong(static_cast<long>(i));
   PyObject* pyValue = PyFloat_FromDouble(value);
   PyObject_CallMethodObjArgs(pyVector_,method_["__setitem__"].name,pyIndex,pyValue,NULL);
+  if (PyErr_Occurred() != NULL) PyErr_Print();
   Py_DECREF(pyValue);
   Py_DECREF(pyIndex);
 }
@@ -264,6 +277,7 @@ void PythonVector::setValue (int i, double value) {
 double PythonVector::getValue(int i) const {
   PyObject* pyIndex = PyLong_FromLong(static_cast<long>(i));
   PyObject* pyValue = PyObject_CallMethodObjArgs(pyVector_,method_["__getitem__"].name,pyIndex,NULL);
+  if (PyErr_Occurred() != NULL) PyErr_Print();
   TEUCHOS_TEST_FOR_EXCEPTION(!PyFloat_Check(pyValue), std::logic_error,
                              "__getitem__ returned incorrect type");
   double value = PyFloat_AsDouble(pyValue);


### PR DESCRIPTION
* Check if Python has had an error, in which case call `PyErr_Print()`
* Check for correct return types using `TEUCHOS_TEST_FOR_EXCEPTION`
 - maybe this should really throw a Python error? Anyway, it works OK for now.
